### PR TITLE
Expanded acronyms

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
   // Implements various security types such as:
   //   savings accounts (compounding periodic interest)
   //   bonds (periodic interest, no compounding, market pricing, maturity date, premium/discount)
-  //   stocks (no interest, optional dividends without reinvestment unless in a DRIP, market pricing)
+  //   stocks (no interest, optional dividends without reinvestment unless in a DRIP (dividend reinvestment plan), market pricing)
   //   mutual funds (no interest, dividends, capital gains, fees (hidden?), compounding, market pricing)
-  //   ETFs (no interest, dividends, capital gains, fees, compounding, market pricing)
+  //   ETFs (exchange traded funds) (no interest, dividends, capital gains, fees, compounding, market pricing)
   function Security(){
   }
   // ORDER class


### PR DESCRIPTION
DRIP and ETF don't make much sense to the new investor.